### PR TITLE
Fix compile errors

### DIFF
--- a/include/LinkedList.h
+++ b/include/LinkedList.h
@@ -272,7 +272,7 @@ private:
      * element of this list (if one exists). We use a smart pointer in order to
      * achieve strong exception safety in certain methods.
      */
-    std::auto_ptr<LinkedListNode<T> > mTail;
+    std::unique_ptr<LinkedListNode<T> > mTail;
 };
 
 /**

--- a/tests/queueTest.cpp
+++ b/tests/queueTest.cpp
@@ -28,12 +28,23 @@ TEST_P(QueueTest, Empty) {
         QueueBase<int>* q = makeIntQueue(GetParam());
         EXPECT_TRUE(q->isEmpty());
         EXPECT_EQ(q->size(), 0UL);
+
         EXPECT_THROW({
                              q->dequeue();
                      }, QueueBase<int>::Underflow);
+
+        delete q;
+    });
+
+    EXPECT_NO_THROW({
+        QueueBase<int>* q = makeIntQueue(GetParam());
+        EXPECT_TRUE(q->isEmpty());
+        EXPECT_EQ(q->size(), 0UL);
+
         EXPECT_THROW({
                              q->front();
                      }, QueueBase<int>::Underflow);
+
         delete q;
     });
 }

--- a/tests/stackTest.cpp
+++ b/tests/stackTest.cpp
@@ -49,9 +49,18 @@ TEST_P(StackTest, Empty) {
                  stack->pop();
          }, StackBase<int>::Underflow);
 
+        delete stack;
+    });
+
+    EXPECT_NO_THROW({
+        StackBase<int>* stack = makeIntStack(GetParam());
+        EXPECT_TRUE(stack->isEmpty());
+        EXPECT_EQ(stack->size(), 0UL);
+
         EXPECT_THROW({
                  stack->top();
          }, StackBase<int>::Underflow);
+
         delete stack;
     });
 }


### PR DESCRIPTION
Closes #1 and #2. Should be able to successfully compile and run tests after this.

Note that this means that students should *not* need to disable any of the compiler flags in CMakeLists.txt.